### PR TITLE
require sudo for package manager

### DIFF
--- a/tasks/Archlinux.yml
+++ b/tasks/Archlinux.yml
@@ -15,6 +15,7 @@
   when: wine_release == "staging"
 
 - name: Installing the official Wine package provided by Arch Linux
+  become: true
   pacman:
     name: "{{ wine_package }}"
     state: present

--- a/tasks/EL.yml
+++ b/tasks/EL.yml
@@ -1,17 +1,20 @@
 ---
 - name: Install EPEL (CentOS)
+  become: true
   package:
     name: epel-release
     state: present
   when: ansible_distribution == "CentOS"
 
 - name: Install EPEL (RHEL)
+  become: true
   package:
     name: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm
     state: present
   when: ansible_distribution == "EL"
 
 - name: Install Wine
+  become: true
   package:
     name: wine
     state: present

--- a/tasks/Fedora.yml
+++ b/tasks/Fedora.yml
@@ -1,5 +1,6 @@
 ---
 - name: Installing the WineHQ repository for Fedora
+  become: true
   copy:
     src: winehq_fedora.repo
     dest: /etc/yum.repos.d/winehq.repo
@@ -34,12 +35,14 @@
         (not use_distro_packages | bool)
 
 - name: Installing the WineHQ packages for Fedora
+  become: true
   dnf:
     name: "{{ wine_package['name'] }}"
     state: present
   when: not use_distro_packages | bool
 
 - name: Creating symlink to the Wine binary
+  become: true
   file:
     src: "{{ wine_package['dir'] }}/bin/wine64"
     dest: "/usr/bin/winehq"
@@ -47,6 +50,7 @@
   when: not use_distro_packages | bool
 
 - name: Installing the official Wine Staging release provided by Fedora
+  become: true
   dnf:
     name: wine
     state: present

--- a/tasks/other.yml
+++ b/tasks/other.yml
@@ -1,5 +1,6 @@
 ---
 - name: Attempting to install Wine on a unsupported platform
+  become: true
   package:
     name: wine
     state: present


### PR DESCRIPTION
Every package manager probably need sudo permissions (``become: true``).

I added them in this Pull Request