### PR TITLE
Resolving ansible-lint errors

### DIFF
--- a/tasks/Archlinux.yml
+++ b/tasks/Archlinux.yml
@@ -1,18 +1,21 @@
 ---
-- fail:
+- name: check if we have to use aur
+  fail:
     msg: "wine-stable has to be installed from the AUR."
   when: wine_release == "stable"
 
-- set_fact:
+- name: set wine fact
+  set_fact:
     wine_package: wine
   when: wine_release == "development"
 
-- set_fact:
+- name: set wine-staging fact
+  set_fact:
     wine_package: wine-staging
   when: wine_release == "staging"
 
 - name: Installing the official Wine package provided by Arch Linux
   pacman:
     name: "{{ wine_package }}"
-    state: latest
+    state: present
     update_cache: yes

--- a/tasks/Fedora.yml
+++ b/tasks/Fedora.yml
@@ -7,44 +7,47 @@
     owner: root
     group: root
     backup: no
-  when: not use_distro_packages
+  when: not use_distro_packages | bool
 
-- set_fact:
+- name: set wine-stable64 fact
+  set_fact:
     wine_package:
       name: wine-stable64
       dir: /opt/wine-stable
   when: (wine_release == "stable") and
-        (not use_distro_packages)
+        (not use_distro_packages | bool)
 
-- set_fact:
+- name: set wine-development64 fact
+  set_fact:
     wine_package:
       name: wine-development64
       dir: /opt/wine-devel
   when: (wine_release == "development") and
-        (not use_distro_packages)
+        (not use_distro_packages | bool)
 
-- set_fact:
+- name: set wine wine-staging64 fact
+  set_fact:
     wine_package:
       name: wine-staging64
       dir: /opt/wine-staging
   when: (wine_release == "staging") and
-        (not use_distro_packages)
+        (not use_distro_packages | bool)
 
 - name: Installing the WineHQ packages for Fedora
   dnf:
     name: "{{ wine_package['name'] }}"
-    state: latest
-  when: not use_distro_packages
+    state: present
+  when: not use_distro_packages | bool
 
 - name: Creating symlink to the Wine binary
   file:
     src: "{{ wine_package['dir'] }}/bin/wine64"
     dest: "/usr/bin/winehq"
     state: link
-  when: not use_distro_packages
+  when: not use_distro_packages | bool
 
 - name: Installing the official Wine Staging release provided by Fedora
   dnf:
     name: wine
-    state: latest
-  when: use_distro_packages
+    state: present
+  when: use_distro_packages | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,10 @@
       command: wineboot --init
 
     - name: Prevent pictures and other formats from opening up with Wine
-      shell: "rm -r -f -v {{ item }}"
+      command: "rm -r -f -v {{ item }}"
       loop: "{{ wine_shorcut_associations }}"
+      args:
+        warn: false
+      changed_when: false
   become: True
   become_user: "{{ wine_user }}"

--- a/tasks/other.yml
+++ b/tasks/other.yml
@@ -2,4 +2,4 @@
 - name: Attempting to install Wine on a unsupported platform
   package:
     name: wine
-    state: latest
+    state: present


### PR DESCRIPTION
resolve ansible lint errors and add ``| bool`` at some boolean operators (fedora).